### PR TITLE
Implement NetworkManager-based WiFi switching with persistence

### DIFF
--- a/public/js/network.js
+++ b/public/js/network.js
@@ -263,14 +263,15 @@ class NetworkUI {
             const { active, clients, ip, ssid } = apData;
             const clientCount = clients ? clients.length : 0;
 
-            const status = active ? 'Active' : 'Inactive';
+            // Show SSID if available and active, otherwise show status
+            const displayStatus = active ? (ssid || 'Active') : 'Inactive';
 
             // Update settings page
-            if (statusElement) statusElement.textContent = status;
+            if (statusElement) statusElement.textContent = displayStatus;
             if (clientsDetailElement) clientsDetailElement.textContent = `${clientCount} connected`;
 
-            // Update main page
-            if (mainStatusElement) mainStatusElement.textContent = status;
+            // Update main page - show SSID for AP status
+            if (mainStatusElement) mainStatusElement.textContent = displayStatus;
             if (headerClientsElement) headerClientsElement.textContent = clientCount.toString();
 
             // Update SSID if element exists

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -681,6 +681,17 @@ export function createApiRouter(getCameraController, powerManager, server, netwo
       }
     });
 
+    // Get saved WiFi networks - LOW-LEVEL SERVICE OPERATION
+    router.get('/network/wifi/saved', async (req, res) => {
+      try {
+        const networks = await networkServiceManager.getSavedNetworks();
+        res.json({ networks });
+      } catch (error) {
+        logger.error('Failed to get saved WiFi networks:', error);
+        res.status(500).json({ error: error.message });
+      }
+    });
+
     // Remove saved WiFi network - LOW-LEVEL SERVICE OPERATION
     router.delete('/network/wifi/saved/:id', async (req, res) => {
       try {


### PR DESCRIPTION
## Summary
- Replace wpa_supplicant/wpa_cli approach with NetworkManager/nmcli commands to fix WiFi switching
- Resolve root cause: Pi uses NetworkManager, not wpa_supplicant directly (raspi-config failures were normal)
- Fix network status display issues showing "preconfigured" instead of actual SSID names
- Add comprehensive WiFi connection management with persistence across reboots

## Key Changes
- **WiFi Scanning**: Switch from `iw`/`wpa_cli` to `nmcli dev wifi list` with signal strength and security info
- **WiFi Connection**: Use `nmcli dev wifi connect` with automatic profile management and conflict resolution  
- **Status Detection**: Extract actual SSID from active connections instead of connection profile names
- **Access Point Display**: Show SSID ("PiCameraController") instead of generic "Active" status
- **Connection Verification**: 5-second async verification with signal strength monitoring
- **API Enhancement**: Add `/api/network/wifi/saved` endpoint for saved networks management

## Network Architecture
- Maintains dual interface design: wlan0 (WiFi client) + ap0 (Access Point broadcast)
- Proper persistence via NetworkManager's built-in connection profiles
- Handles networks on same subnet correctly (both MDNet and MDNet-guest use 192.168.12.0/24)
- Compatible with existing NetworkStateManager/NetworkServiceManager separation

## Test Results
✅ **WiFi Scanning**: Shows available networks with signal strength percentages  
✅ **Network Switching**: Successfully switches between MDNet ↔ MDNet-guest  
✅ **Status Display**: Shows actual SSIDs instead of connection profile names  
✅ **Reboot Persistence**: Pi reconnects to selected network after power cycle  
✅ **Web Interface**: Real-time feedback during connection process with connectivity warnings  
✅ **Dual Network**: Access Point remains active while WiFi client switches networks  

## Network Discovery Resolution
The investigation revealed that:
- Pi was already using NetworkManager (confirmed via `systemctl status NetworkManager`) 
- Previous wpa_supplicant-based approach was incompatible with NetworkManager management
- raspi-config WiFi failures were expected behavior (it assumes wpa_supplicant control)
- NetworkManager provides superior connection management and persistence

## Implementation Details
```bash
# NetworkManager commands now used:
nmcli -t -f NAME,TYPE,DEVICE con show --active  # Get active connections
nmcli -t -f IN-USE,SSID,SIGNAL dev wifi list    # Scan with signal strength  
nmcli dev wifi connect "SSID" password "pass"   # Connect to network
nmcli con delete "ConnectionName"                # Remove old profiles
```

🤖 Generated with [Claude Code](https://claude.ai/code)