### PR TITLE
Fix: Restore timelapse reports functionality

### DIFF
--- a/public/js/camera.js
+++ b/public/js/camera.js
@@ -1395,6 +1395,11 @@ WebSocket: ${wsManager.connected ? 'Connected' : 'Disconnected'}
       if (window.utilitiesManager) {
         window.utilitiesManager.initialize();
       }
+    } else if (cardName === 'timelapse-reports') {
+      // Load timelapse reports when the card is shown
+      if (window.timelapseUI) {
+        window.timelapseUI.loadReports();
+      }
     }
     
     // Update menu active states
@@ -1509,7 +1514,8 @@ WebSocket: ${wsManager.connected ? 'Connected' : 'Disconnected'}
   updateProgressDisplay(status) {
     try {
       console.log('updateProgressDisplay called with:', status);
-      
+      console.log('nextShotTime in status:', status.nextShotTime);
+
       // Safely get values with fallbacks
       const stats = status.stats || {};
       const options = status.options || {};
@@ -1553,7 +1559,7 @@ WebSocket: ${wsManager.connected ? 'Connected' : 'Disconnected'}
         const nextShotIn = Math.max(0, nextShotTime - now);
         
         if (nextShotIn <= 1000) {
-          document.getElementById('next-shot-countdown').textContent = 'Taking shot...';
+          document.getElementById('next-shot-countdown').textContent = 'Now';
         } else {
           document.getElementById('next-shot-countdown').textContent = `${Math.ceil(nextShotIn / 1000)}s`;
         }

--- a/public/js/timelapse.js
+++ b/public/js/timelapse.js
@@ -54,7 +54,12 @@ class TimelapseUI {
 
     // WebSocket event handlers
     if (this.wsManager) {
+      // Report data responses
       this.wsManager.on('timelapse_reports_response', (data) => {
+        this.handleReportsResponse(data);
+      });
+
+      this.wsManager.on('timelapse_reports', (data) => {
         this.handleReportsResponse(data);
       });
 
@@ -62,6 +67,7 @@ class TimelapseUI {
         this.handleReportResponse(data);
       });
 
+      // Session events
       this.wsManager.on('session_completed', (data) => {
         this.handleSessionCompleted(data);
       });
@@ -76,6 +82,14 @@ class TimelapseUI {
 
       this.wsManager.on('unsaved_session_found', (data) => {
         this.handleUnsavedSessionFound(data);
+      });
+
+      this.wsManager.on('report_saved', (data) => {
+        this.loadReports(); // Refresh the list after saving
+      });
+
+      this.wsManager.on('report_deleted', (data) => {
+        this.loadReports(); // Refresh the list after deleting
       });
     }
   }
@@ -420,6 +434,7 @@ class TimelapseUI {
    * Handle session completed event
    */
   handleSessionCompleted(data) {
+    this.unsavedSession = data;
     this.showSessionCompletion(data, 'completed');
   }
 
@@ -427,6 +442,7 @@ class TimelapseUI {
    * Handle session stopped event
    */
   handleSessionStopped(data) {
+    this.unsavedSession = data;
     this.showSessionCompletion(data, 'stopped');
   }
 
@@ -434,6 +450,7 @@ class TimelapseUI {
    * Handle session error event
    */
   handleSessionError(data) {
+    this.unsavedSession = data;
     this.showSessionCompletion(data, 'error');
   }
 

--- a/public/js/websocket.js
+++ b/public/js/websocket.js
@@ -195,6 +195,15 @@ class WebSocketManager {
           this.emit(eventType, data);
         }
         break;
+
+      case 'timelapse_event':
+        // Handle timelapse-specific events
+        if (eventType) {
+          console.log('Received timelapse event:', eventType, data);
+          // Emit the specific event type (e.g., session_completed, session_stopped, etc.)
+          this.emit(eventType, data);
+        }
+        break;
         
       case 'photo_taken':
         this.emit('photo_taken', data);

--- a/src/intervalometer/timelapse-session.js
+++ b/src/intervalometer/timelapse-session.js
@@ -349,9 +349,10 @@ export class TimelapseSession extends EventEmitter {
       this.nextShotTime = now;
     } else {
       // Subsequent shots - calculate based on interval from start time
-      // shotsTaken has already been incremented in takeShot(), so use it directly
-      const nextShotInterval = this.stats.shotsTaken;
-      this.nextShotTime = new Date(this.stats.startTime.getTime() + (nextShotInterval * this.options.interval * 1000));
+      // After shot N is taken, shotsTaken = N, and we schedule shot N+1
+      // Shot 1 at time 0, shot 2 at 1*interval, shot 3 at 2*interval, etc.
+      // So for the next shot (N+1), we use shotsTaken as the multiplier since shot 1 was at 0
+      this.nextShotTime = new Date(this.stats.startTime.getTime() + (this.stats.shotsTaken * this.options.interval * 1000));
     }
     
     // Calculate delay until next shot time
@@ -386,7 +387,11 @@ export class TimelapseSession extends EventEmitter {
       
       this.stats.shotsTaken++;
       this.stats.shotsSuccessful++;
-      
+
+      // Immediately update nextShotTime for the UI
+      // After shot N, the next shot (N+1) will be at startTime + (N * interval)
+      this.nextShotTime = new Date(this.stats.startTime.getTime() + (this.stats.shotsTaken * this.options.interval * 1000));
+
       logger.info(`Shot ${shotNumber} completed successfully`, {
         sessionId: this.id,
         title: this.title,

--- a/src/websocket/handler.js
+++ b/src/websocket/handler.js
@@ -587,15 +587,15 @@ export function createWebSocketHandler(cameraController, powerManager, server, n
         options.stopTime = stopDate;
       }
       
-      server.activeIntervalometerSession = new IntervalometerSession(() => cameraController(), options);
-      
+      server.activeIntervalometerSession = await intervalometerStateManager.createSession(() => cameraController(), options);
+
       // Set up event handlers with enhanced events for reporting
       server.activeIntervalometerSession.on('started', (sessionData) => {
         logger.info('Session started event received, broadcasting...');
         broadcastEvent('intervalometer_started', {
           ...sessionData,
-          sessionId: server.activeIntervalometerSession.getSessionId(),
-          title: server.activeIntervalometerSession.getTitle()
+          sessionId: server.activeIntervalometerSession.id,
+          title: server.activeIntervalometerSession.title
         });
       });
       
@@ -651,8 +651,8 @@ export function createWebSocketHandler(cameraController, powerManager, server, n
         success: true,
         message: 'Intervalometer started successfully',
         status: server.activeIntervalometerSession.getStatus(),
-        sessionId: server.activeIntervalometerSession.getSessionId(),
-        title: server.activeIntervalometerSession.getTitle()
+        sessionId: server.activeIntervalometerSession.id,
+        title: server.activeIntervalometerSession.title
       });
     } catch (error) {
       logger.error('Failed to start intervalometer with title via WebSocket:', error);


### PR DESCRIPTION
## Summary
- Fixes the broken timelapse reports feature that stopped working
- Restores proper integration between intervalometer sessions and report generation
- Fixes UI issues with countdown timer display

## Problem
The timelapse reports functionality had stopped working. When intervalometer sessions completed, no reports were generated or displayed. The root cause was that the system was using the legacy `IntervalometerSession` class instead of the new `TimelapseSession` which has report generation capabilities.

## Solution
1. **Backend Integration**: Changed to use `intervalometerStateManager.createSession()` which creates `TimelapseSession` objects with report generation
2. **API Compatibility**: Fixed method calls to use properties (`.id` instead of `getSessionId()`)
3. **Frontend Data Flow**: Added missing session data storage in event handlers
4. **UI Improvements**: Fixed "Next Shot" countdown display

## Changes Made
- ✅ Use centralized state manager for session creation
- ✅ Fix API compatibility issues between session types
- ✅ Store session data in frontend for report saving
- ✅ Add timelapse event handling in WebSocket client
- ✅ Improve countdown display ("Now" instead of "Taking shot...")
- ✅ Fix nextShotTime calculation for accurate countdown

## Test Results
- Intervalometer sessions now complete successfully
- Reports are generated after session completion
- User can save or discard sessions through the UI
- Countdown timer displays correctly (when Pi clock is synced)

🤖 Generated with [Claude Code](https://claude.ai/code)