### PR TITLE
Fix Canon API usage and enhance error logging

### DIFF
--- a/canon-ccapi-endpoints.md
+++ b/canon-ccapi-endpoints.md
@@ -1,0 +1,58 @@
+# Canon CCAPI Endpoints Used in Pi Camera Control
+
+This document lists all Canon CCAPI endpoints called by the pi-camera-control application.
+
+## GET Requests
+
+### 1. `/ccapi/`
+- **Purpose**: CCAPI discovery/capabilities endpoint
+- **Usage**: Used during camera connection to discover available API endpoints and versions
+- **File**: `src/camera/controller.js:86`
+- **Context**: Initial connection and periodic connection monitoring
+
+### 2. `/ccapi/ver100/shooting/settings`
+- **Purpose**: Get camera shooting settings
+- **Usage**: Retrieve current camera shooting parameters (ISO, aperture, shutter speed, etc.)
+- **File**: `src/camera/controller.js:150` (main call), `97` (verification), `422` (polling)
+- **Context**: Called when getting camera settings for UI display and during info polling
+
+### 3. `/ccapi/ver100/deviceinformation`
+- **Purpose**: Get camera device information
+- **Usage**: Retrieve camera manufacturer, model, serial number, MAC address, firmware version
+- **File**: `src/camera/controller.js:175`
+- **Context**: Called at timelapse session start to collect camera info for reports
+
+### 4. `/ccapi/ver110/devicestatus/batterylist`
+- **Purpose**: Get detailed battery information (newer API)
+- **Usage**: Retrieve comprehensive battery status information
+- **File**: `src/camera/controller.js:205`
+- **Context**: Primary battery status endpoint, falls back to ver100 if not available
+
+### 5. `/ccapi/ver100/devicestatus/battery`
+- **Purpose**: Get basic battery information (fallback)
+- **Usage**: Retrieve basic battery status for older cameras
+- **File**: `src/camera/controller.js:210`
+- **Context**: Fallback when ver110/batterylist is not available
+
+## POST Requests
+
+### 6. `/ccapi/ver100/shooting/control/shutterbutton/manual`
+- **Purpose**: Manual shutter control (preferred)
+- **Usage**: Press/release shutter with manual focus control
+- **File**: `src/camera/controller.js:291, 323` (via `this.shutterEndpoint`)
+- **Context**: Preferred endpoint for taking photos during timelapse sessions
+- **Payload**: `{ af: boolean, action: "full_press"|"release" }`
+
+### 7. `/ccapi/ver100/shooting/control/shutterbutton`
+- **Purpose**: Regular shutter control (fallback)
+- **Usage**: Press/release shutter with standard control
+- **File**: `src/camera/controller.js:291, 323` (via `this.shutterEndpoint`)
+- **Context**: Fallback when manual endpoint is not available
+- **Payload**: `{ af: boolean, action: "full_press"|"release" }`
+
+## Notes
+
+- The shutter endpoint (6 or 7) is determined dynamically by examining the camera's capabilities
+- We prefer the "manual" endpoint if available, otherwise fall back to the regular one
+- All endpoints should return status codes: 200 (success), 400 (bad request), or 503 (service unavailable)
+- Error responses should include a JSON body with a "message" field containing details

--- a/public/js/timelapse.js
+++ b/public/js/timelapse.js
@@ -91,6 +91,11 @@ class TimelapseUI {
       this.wsManager.on('report_deleted', (data) => {
         this.loadReports(); // Refresh the list after deleting
       });
+
+      // Handle session discard response
+      this.wsManager.on('session_discarded', (data) => {
+        this.handleSessionDiscarded();
+      });
     }
   }
 
@@ -598,7 +603,19 @@ class TimelapseUI {
   handleSessionDiscarded() {
     this.unsavedSession = null;
     this.hideSessionCompletion();
-    this.switchToCard('controller-status');
+    // Return to intervalometer page after discarding
+    if (window.CameraUI && window.CameraUI.switchToCard) {
+      window.CameraUI.switchToCard('intervalometer');
+    } else {
+      // Fallback to showing the intervalometer card directly
+      document.querySelectorAll('.function-card').forEach(card => {
+        card.style.display = 'none';
+      });
+      const intervalometerCard = document.getElementById('intervalometer-card');
+      if (intervalometerCard) {
+        intervalometerCard.style.display = 'block';
+      }
+    }
     this.showSuccess('Session discarded');
   }
 

--- a/src/intervalometer/report-manager.js
+++ b/src/intervalometer/report-manager.js
@@ -115,15 +115,31 @@ export class TimelapseReportManager {
    * Validate report structure
    */
   validateReport(report) {
-    const requiredFields = ['id', 'sessionId', 'title', 'startTime', 'status', 'settings', 'results', 'metadata'];
-    
-    for (const field of requiredFields) {
+    // Support both old and new report structures during transition
+    const requiredFieldsV2 = ['id', 'sessionId', 'title', 'startTime', 'status', 'intervalometer', 'results', 'metadata'];
+    const requiredFieldsV1 = ['id', 'sessionId', 'title', 'startTime', 'status', 'settings', 'results', 'metadata'];
+
+    // Check for v2 structure first
+    let isV2Valid = true;
+    for (const field of requiredFieldsV2) {
+      if (!report.hasOwnProperty(field)) {
+        isV2Valid = false;
+        break;
+      }
+    }
+
+    if (isV2Valid) {
+      return true;
+    }
+
+    // Fall back to v1 structure
+    for (const field of requiredFieldsV1) {
       if (!report.hasOwnProperty(field)) {
         logger.debug('Report missing required field:', { field, reportId: report.id });
         return false;
       }
     }
-    
+
     return true;
   }
   

--- a/src/intervalometer/state-manager.js
+++ b/src/intervalometer/state-manager.js
@@ -435,8 +435,9 @@ export class IntervalometerStateManager extends EventEmitter {
    */
   generateSessionReport(session, completionData = null) {
     const status = session.getStatus();
+    const metadata = session.getMetadata();
     const now = new Date();
-    
+
     return {
       id: `report-${session.id}`,
       sessionId: session.id,
@@ -444,19 +445,18 @@ export class IntervalometerStateManager extends EventEmitter {
       startTime: status.stats.startTime,
       endTime: status.stats.endTime || now,
       duration: status.duration,
-      status: completionData ? 
-        (completionData.reason.includes('error') ? 'error' : 
-         completionData.reason.includes('Stopped') ? 'stopped' : 'completed') : 
+      status: completionData ?
+        (completionData.reason.includes('error') ? 'error' :
+         completionData.reason.includes('Stopped') ? 'stopped' : 'completed') :
         status.state,
-      settings: {
+      intervalometer: {
         interval: status.options.interval,
-        totalShots: status.options.totalShots,
-        stopTime: status.options.stopTime,
-        // TODO: Add camera settings when available
-        shutterSpeed: 'auto',
-        iso: 'auto', 
-        aperture: 'auto'
+        stopCondition: status.options.stopCondition || 'unlimited',
+        numberOfShots: status.options.totalShots,
+        stopAt: status.options.stopTime
       },
+      cameraInfo: metadata.cameraInfo || null,
+      cameraSettings: metadata.cameraSettings || null,
       results: {
         imagesCaptured: status.stats.shotsTaken,
         imagesSuccessful: status.stats.shotsSuccessful,
@@ -466,8 +466,8 @@ export class IntervalometerStateManager extends EventEmitter {
       metadata: {
         completionReason: completionData?.reason || 'Unknown',
         savedAt: now,
-        version: '1.0.0', // TODO: Get from package.json
-        cameraModel: 'Unknown' // TODO: Get from camera controller
+        version: '2.0.0',
+        cameraModel: metadata.cameraInfo?.productname || 'Unknown'
       }
     };
   }


### PR DESCRIPTION
- Fix shutter control to prefer regular shooting endpoint over manual endpoint
- Always use AF: false for timelapse photography per Canon documentation
- Add proper error logging with Canon API status codes and messages
- Add getDeviceInformation() method to fetch camera metadata
- Extend timelapse sessions to capture camera info and settings at start
- Update report structure to include intervalometer parameters and camera data
- Fix session discard UI to return to intervalometer page
- Add comprehensive Canon CCAPI endpoint documentation

🤖 Generated with [Claude Code](https://claude.ai/code)