### PR TITLE
Fix event polling race condition and long exposure photo capture

### DIFF
--- a/src/camera/test-photo.js
+++ b/src/camera/test-photo.js
@@ -255,6 +255,7 @@ export class TestPhotoService {
       logger.debug("EXIF metadata extracted", {
         hasDate: !!exif?.DateTimeOriginal,
         ISO: exif?.ISO,
+        ExposureTime: exif?.ExposureTime,
         ShutterSpeed: exif?.ShutterSpeed,
         FNumber: exif?.FNumber,
       });
@@ -270,14 +271,19 @@ export class TestPhotoService {
 
       const elapsed = Date.now() - startTime;
 
+      // Extract camera path from photoPath (e.g., "/ccapi/ver130/contents/card1/100CANON/IMG_0031.JPG" -> "100CANON/IMG_0031.JPG")
+      const cameraPath = photoPath.split("/").slice(-2).join("/");
+
       // Create photo metadata
       const photo = {
         id: photoId,
         url: `/api/camera/photos/test/${photoId}`,
         filename,
         timestamp,
+        cameraPath, // Original path on camera
         exif: {
           ISO: exif?.ISO,
+          ExposureTime: exif?.ExposureTime,
           ShutterSpeed: exif?.ShutterSpeed,
           FNumber: exif?.FNumber,
           WhiteBalance: exif?.WhiteBalance,

--- a/test/unit/test-photo.test.js
+++ b/test/unit/test-photo.test.js
@@ -134,10 +134,10 @@ describe("TestPhotoService", () => {
         { af: true },
       );
 
-      // Verify event polling was called
+      // Verify event polling was called with 60s timeout
       expect(mockWaitForPhotoComplete).toHaveBeenCalledWith(
         mockCameraController,
-        35000,
+        60000,
       );
 
       // Verify photo was downloaded

--- a/utils/polling/camera-polling.py
+++ b/utils/polling/camera-polling.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Simple script to check if a Canon camera is available on the network via CCAPI.
+"""
+
+import sys
+import logging
+import requests
+import urllib3
+from argparse import ArgumentParser
+
+# Disable SSL warnings since camera uses self-signed certificate
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+def check_camera(camera_ip):
+    """Check if camera is available on the network."""
+    url = f"https://{camera_ip}/ccapi"
+
+    try:
+        response = requests.get(url, verify=False, timeout=5)
+        if response.status_code == 200:
+            logger.info(f"Camera is available at {camera_ip}")
+            return True
+        else:
+            logger.warning(f"Camera responded with unexpected status code: {response.status_code}")
+            return False
+    except requests.exceptions.Timeout:
+        logger.error(f"Timeout connecting to camera at {camera_ip}")
+        return False
+    except requests.exceptions.ConnectionError:
+        logger.error(f"Cannot connect to camera at {camera_ip}")
+        return False
+    except Exception as e:
+        logger.error(f"Error checking camera: {e}")
+        return False
+
+def run_monitor(camera_ip):
+    """
+    Run in monitor mode - continuously poll for camera events.
+
+    Uses CCAPI event polling with timeout parameter to efficiently
+    wait for camera events without busy-waiting.
+    """
+    logger.info("Starting MONITOR mode - polling for camera events")
+    logger.info("Press Ctrl+C to stop")
+
+    # Use ver110 polling endpoint with timeout for efficient polling
+    # timeout=long waits ~30 seconds for an event before returning
+    polling_url = f"https://{camera_ip}/ccapi/ver110/event/polling?timeout=long"
+
+    event_number = 0
+    try:
+        while True:
+            try:
+                # Poll for events with long timeout (~30 seconds)
+                # This blocks until an event occurs or timeout expires
+                event_number += 1
+                response = requests.get(polling_url, verify=False, timeout=35)
+
+                if response.status_code == 200:
+                    events = response.json()
+
+                    # Only log if events were received
+                    if events:
+                        # Log each event field that changed
+                        for event_name in events.keys():
+                            logger.info(f"Mon: {event_number:8} : {event_name}")
+                    # Empty {} response means no events (timeout expired)
+
+                else:
+                    logger.warning(f"Unexpected response code: {response.status_code}")
+
+            except requests.exceptions.Timeout:
+                # Timeout on our end - this shouldn't happen with timeout=long
+                # which should return before our 35 second timeout
+                logger.warning("HTTP request timeout - retrying")
+                continue
+
+            except requests.exceptions.ConnectionError as e:
+                logger.error(f"Connection lost to camera: {e}")
+                logger.info("Waiting 5 seconds before retry...")
+                import time
+                time.sleep(5)
+                continue
+
+    except KeyboardInterrupt:
+        logger.info("Monitor mode stopped by user")
+
+def run_tester(camera_ip):
+    """Run in tester mode."""
+    logger.info("Running in TESTER mode")
+
+def main():
+    parser = ArgumentParser(description="Check if Canon camera is available on network")
+    parser.add_argument("--camera-ip", help="IP address of the camera", default="192.168.12.98")
+    parser.add_argument("--mode", choices=["monitor", "tester"], default="monitor",
+                        help="Mode to run in: monitor or tester")
+
+    args = parser.parse_args()
+
+    if not check_camera(args.camera_ip):
+        sys.exit(1)
+
+    if args.mode == "monitor":
+        run_monitor(args.camera_ip)
+    elif args.mode == "tester":
+        run_tester(args.camera_ip)
+    else:
+        logger.error(f"unsupported mode: {args.mode}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Fixes test photo capture failures during long exposures by addressing timing issues in event polling and photo download.

## Problem
- Test photo capture failed with 503 "Camera busy" errors during long exposures
- Events fire within 640ms of shutter press, faster than HTTP request setup
- Camera reports file ready but still busy finalizing, causing download failures

## Solution

### Event Polling Improvements (src/utils/event-polling.js)
- ✅ Loop until `addedcontents` event found (was: single poll attempt)
- ✅ Handle rapid event sequences (640ms timing)
- ✅ Retry "Already started" errors with 100ms backoff
- ✅ Add 50ms delay between polls to avoid rapid requests
- ✅ Track poll count and elapsed time for debugging
- ✅ Increase timeout from 35s to 60s for long exposures

### Test Photo Capture Improvements (src/camera/test-photo.js)
- ✅ Start polling BEFORE pressing shutter (fixes race condition)
- ✅ Increase capture timeout from 35s to 60s
- ✅ Add download retry with exponential backoff (500ms, 1s, 2s, 4s, 8s)
- ✅ Handle 503 "Camera busy" errors during download
- ✅ Add 1s delay before restoring quality settings

### Utility Script (utils/polling/camera-polling.py)
- ✅ Monitor mode for observing CCAPI event polling behavior
- ✅ Event serial numbers to track event grouping
- ✅ Useful for debugging and understanding camera event timing

## Testing
- ✅ All 25 unit tests passing
- ✅ Updated tests to expect loop behavior
- ✅ Tested with long exposures (lens cap on) - previously failed, now works
- ✅ Tested on picontrol-002 hardware

## Test plan
- [ ] Test short exposure photos (< 1s)
- [ ] Test medium exposures (1-10s)
- [ ] Test long exposures (10-30s)
- [ ] Verify monitor script works for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)