### PR TITLE
Add SD card storage monitoring to header indicator

### DIFF
--- a/docs/design/api-specification.md
+++ b/docs/design/api-specification.md
@@ -75,6 +75,66 @@ Returns camera battery status and information.
 
 **Note:** Format matches Canon CCAPI v1.40 specification. The `level` field is returned as a string, not a number. Additional fields include `position` (camera location), `kind` (battery type), and standard `quality` values ("bad", "normal", "good", "unknown").
 
+#### Get Camera Storage
+
+```http
+GET /api/camera/storage
+```
+
+Returns SD card storage information from the camera.
+
+**Response (SD card mounted):**
+
+```json
+{
+  "mounted": true,
+  "name": "card1",
+  "totalBytes": 32000000000,
+  "freeBytes": 8000000000,
+  "usedBytes": 24000000000,
+  "totalMB": 30517,
+  "freeMB": 7629,
+  "usedMB": 22888,
+  "percentUsed": 75,
+  "contentCount": 1234,
+  "accessMode": "readwrite"
+}
+```
+
+**Response (No SD card):**
+
+```json
+{
+  "mounted": false,
+  "name": null,
+  "totalBytes": 0,
+  "freeBytes": 0,
+  "usedBytes": 0,
+  "totalMB": 0,
+  "freeMB": 0,
+  "usedMB": 0,
+  "percentUsed": 0,
+  "contentCount": 0,
+  "accessMode": null
+}
+```
+
+**Fields:**
+
+- `mounted` (boolean): Whether an SD card is inserted and mounted
+- `name` (string|null): Storage name from camera (e.g., "card1")
+- `totalBytes` (number): Total SD card capacity in bytes
+- `freeBytes` (number): Available free space in bytes
+- `usedBytes` (number): Used space in bytes (calculated: total - free)
+- `totalMB` (number): Total capacity in megabytes
+- `freeMB` (number): Free space in megabytes
+- `usedMB` (number): Used space in megabytes
+- `percentUsed` (number): Percentage of space used (0-100)
+- `contentCount` (number): Total number of files on card
+- `accessMode` (string|null): Access capability ("readwrite" or "readonly")
+
+**Note:** Uses Canon CCAPI v1.10+ endpoint `/ccapi/ver110/devicestatus/storage`. All size values are rounded to nearest megabyte. The `usedBytes` field is calculated as `maxsize - spacesize` from the CCAPI response.
+
 #### Take Photo
 
 ```http
@@ -886,9 +946,27 @@ graph LR
       "wlan0": { "connected": true },
       "ap0": { "active": true }
     }
+  },
+  "storage": {
+    "mounted": true,
+    "totalMB": 30517,
+    "freeMB": 7629,
+    "usedMB": 22888,
+    "percentUsed": 75
   }
 }
 ```
+
+**Storage Field Details:**
+
+- `mounted` (boolean): Whether SD card is present
+- `totalMB` (number): Total capacity in megabytes
+- `freeMB` (number): Available free space in megabytes
+- `usedMB` (number): Used space in megabytes
+- `percentUsed` (number): Percentage used (0-100)
+- Field is `null` when camera is not connected or storage info unavailable
+
+````
 
 ##### Event Notifications
 
@@ -902,7 +980,7 @@ graph LR
     "shotNumber": 25
   }
 }
-```
+````
 
 ##### Discovery Events
 

--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -175,6 +175,7 @@ Main application server that orchestrates all components:
 - Connection monitoring and health checks
 - Photo capture with error recovery
 - Camera settings retrieval
+- SD card storage monitoring via CCAPI v1.10+ `/devicestatus/storage` endpoint
 
 **LiveViewManager** (`src/camera/liveview-manager.js`)
 
@@ -323,6 +324,7 @@ The system uses EventEmitter patterns throughout for loose coupling:
 - **Network Events**: WiFi state changes, AP configuration
 - **Power Events**: Battery status, thermal warnings
 - **Session Events**: Intervalometer start/stop/completion
+- **Storage Events**: SD card capacity and availability updates
 
 ## Configuration Management
 

--- a/docs/frontend-visual-testing-guide.md
+++ b/docs/frontend-visual-testing-guide.md
@@ -1,0 +1,405 @@
+# Frontend Visual Testing Guide
+
+## Overview
+
+This guide describes the **visual testing workflow** that enables Claude Code to "see" UI bugs before code is committed. This solves the problem where Claude claims a feature works but the UI displays incorrect values or broken functionality.
+
+## The Problem
+
+Traditional E2E tests often only verify that **elements exist**, not that they display **correct values** or **function properly**:
+
+```javascript
+// ❌ BAD: Only checks existence
+expect(await page.locator("#camera-status").count()).toBe(1);
+
+// ✅ GOOD: Checks actual value
+const statusText = await page.textContent("#camera-status");
+expect(statusText).toBe("Connected");
+```
+
+## The Solution: Visual Testing Pattern
+
+### Three-Part Approach
+
+1. **Capture Screenshots** - Create visual artifacts Claude can read
+2. **Assert Actual Values** - Verify displayed content, not just presence
+3. **Test Functionality** - Click buttons and verify results
+
+## Using the Visual Helpers
+
+### Import the Helpers
+
+```javascript
+import {
+  captureScreenshot,
+  captureAndExtractValues,
+  testButtonClick,
+  getUIStateSnapshot,
+  waitForWebSocketAndVerify,
+} from "./helpers/visual-helpers.js";
+```
+
+### Pattern 1: Capture and Verify Values
+
+```javascript
+test("should display correct camera status", async ({ page }) => {
+  // Navigate and wait for page to be ready
+  await page.goto("/");
+  await waitForWebSocketAndVerify(page);
+
+  // Capture screenshot and extract values
+  const { screenshotPath, values } = await captureAndExtractValues(
+    page,
+    "camera-status-check",
+    {
+      status: "#camera-status-text",
+      ip: "#camera-ip",
+      battery: "#camera-battery",
+    },
+  );
+
+  // Claude can read this screenshot
+  console.log(`Screenshot: ${screenshotPath}`);
+
+  // Assert actual values
+  expect(values.status.visible).toBe(true);
+  expect(values.status.text).toContain("Connected");
+  expect(values.ip.text).toMatch(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/);
+  expect(values.battery.text).not.toBe("-");
+});
+```
+
+### Pattern 2: Test Button Functionality
+
+```javascript
+test("should open menu when button clicked", async ({ page }) => {
+  await page.goto("/");
+
+  // Test button click with verification function
+  const result = await testButtonClick(
+    page,
+    "#function-menu-toggle",
+    async (page) => {
+      // Verify expected result after click
+      const dropdown = page.locator("#function-menu-dropdown");
+      const visible = await dropdown.isVisible();
+      expect(visible).toBe(true);
+    },
+  );
+
+  // Verify the click worked
+  expect(result.success).toBe(true);
+
+  // Capture screenshot for visual verification
+  await captureScreenshot(page, "menu-opened");
+});
+```
+
+### Pattern 3: Get Complete UI State
+
+```javascript
+test("should have correct UI state", async ({ page }) => {
+  await page.goto("/");
+
+  // Get complete snapshot of UI state
+  const uiState = await getUIStateSnapshot(page);
+
+  // Log for debugging
+  console.log("UI State:", JSON.stringify(uiState, null, 2));
+
+  // Verify states
+  expect(uiState.websocket.connected).toBe(true);
+  expect(uiState.camera.status.visible).toBe(true);
+  expect(uiState.buttons.takePhoto.disabled).toBe(false);
+
+  // Capture screenshot
+  await captureScreenshot(page, "ui-state-check");
+});
+```
+
+## Frontend-Guardian Workflow
+
+When making UI changes, `frontend-guardian` MUST follow this workflow:
+
+### Step 1: Make Code Changes
+
+```javascript
+// Make UI changes as requested
+```
+
+### Step 2: Run Playwright Tests
+
+```bash
+# Start server (if not already running)
+npm start &
+
+# Run E2E tests
+npm run test:e2e
+```
+
+### Step 3: Review Test Results
+
+If tests fail:
+
+1. **Read the test output** - See which assertions failed
+2. **Read the screenshots** - Use Read tool to view captured images
+3. **Analyze the difference** - Compare expected vs actual values
+4. **Fix the code** - Make corrections based on visual evidence
+
+### Step 4: Verify Screenshots
+
+Before claiming a feature works, Claude MUST:
+
+```bash
+# List recent screenshots
+ls -lt test-results/screenshots/ | head -10
+
+# Read key screenshots to visually verify UI
+# Claude can read PNG files with the Read tool
+```
+
+Example:
+
+```javascript
+// After test runs, review the visual evidence
+const screenshotPath =
+  "test-results/screenshots/camera-status-check-2025-01-15.png";
+// Use Read tool to view this image
+```
+
+### Step 5: Confirm Success
+
+Only after:
+
+- ✅ All tests pass
+- ✅ Screenshots reviewed and verified
+- ✅ Actual values match expected values
+
+Can the feature be considered complete.
+
+## Converting Existing Tests
+
+### Before (Element Existence Only)
+
+```javascript
+test("should display camera status", async ({ page }) => {
+  await page.goto("/");
+
+  const status = await page.locator("#camera-status");
+  expect(await status.count()).toBe(1);
+});
+```
+
+### After (Visual Verification)
+
+```javascript
+test("should display camera status", async ({ page }) => {
+  await page.goto("/");
+  await waitForWebSocketAndVerify(page);
+
+  const { screenshotPath, values } = await captureAndExtractValues(
+    page,
+    "camera-status",
+    { status: "#camera-status-text" },
+  );
+
+  console.log(`Screenshot: ${screenshotPath}`);
+
+  expect(values.status.exists).toBe(true);
+  expect(values.status.visible).toBe(true);
+  expect(values.status.text).toBeTruthy();
+  expect(values.status.text.length).toBeGreaterThan(0);
+});
+```
+
+## Screenshot Organization
+
+Screenshots are saved to `test-results/screenshots/` with naming pattern:
+
+```
+{test-name}-{timestamp}.png
+```
+
+Examples:
+
+```
+test-results/screenshots/
+├── camera-status-check-2025-01-15t10-30-00.png
+├── menu-opened-2025-01-15t10-30-01.png
+└── ui-state-check-2025-01-15t10-30-02.png
+```
+
+## Reading Screenshots (For Claude)
+
+When tests complete, Claude should:
+
+```bash
+# List screenshots from recent test run
+ls -lt test-results/screenshots/ | head -5
+```
+
+Then use Read tool on each screenshot:
+
+```javascript
+// Claude uses Read tool internally
+Read(
+  "/Users/mark/git/pi-camera-control/test-results/screenshots/camera-status-check-2025-01-15.png",
+);
+```
+
+This allows Claude to **visually verify** the UI looks correct.
+
+## Common Assertions
+
+### Verify Text Content
+
+```javascript
+expect(values.status.text).toBe("Connected");
+expect(values.status.text).toContain("Camera");
+expect(values.status.text).toMatch(/Connected|Ready/);
+```
+
+### Verify Element State
+
+```javascript
+expect(values.button.visible).toBe(true);
+expect(values.button.disabled).toBe(false);
+expect(values.input.value).toBe("expected-value");
+```
+
+### Verify Patterns
+
+```javascript
+// IP address
+expect(ipText).toMatch(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/);
+
+// Percentage
+expect(batteryText).toMatch(/\d+%/);
+
+// Time format
+expect(timeText).toMatch(/\d{2}:\d{2}:\d{2}/);
+```
+
+## Best Practices
+
+### DO
+
+✅ **Capture screenshots** for every significant test
+✅ **Assert on actual values**, not just existence
+✅ **Test button functionality** by clicking and verifying
+✅ **Log screenshot paths** so Claude can find them
+✅ **Review screenshots** before marking tests as passing
+✅ **Use descriptive test names** that match screenshot names
+
+### DON'T
+
+❌ **Don't skip screenshot capture**
+❌ **Don't only check element existence**
+❌ **Don't claim success without reading screenshots**
+❌ **Don't use fixed timeouts** - use proper wait conditions
+❌ **Don't ignore test failures**
+❌ **Don't assume the UI is correct without visual verification**
+
+## Example Test Flow
+
+```javascript
+import { test, expect } from "@playwright/test";
+import {
+  captureScreenshot,
+  captureAndExtractValues,
+  waitForWebSocketAndVerify,
+} from "./helpers/visual-helpers.js";
+
+test("complete example with visual verification", async ({ page }) => {
+  // 1. Navigate
+  await page.goto("/");
+
+  // 2. Wait for ready state
+  const wsConnected = await waitForWebSocketAndVerify(page);
+  expect(wsConnected).toBe(true);
+
+  // 3. Capture screenshot and values
+  const { screenshotPath, values } = await captureAndExtractValues(
+    page,
+    "my-feature-test",
+    {
+      title: "#page-title",
+      button: "#action-button",
+      result: "#result-display",
+    },
+  );
+
+  // 4. Log for Claude to read
+  console.log(`Screenshot: ${screenshotPath}`);
+  console.log("Values:", JSON.stringify(values, null, 2));
+
+  // 5. Assert actual values
+  expect(values.title.text).toBe("Expected Title");
+  expect(values.button.visible).toBe(true);
+  expect(values.button.disabled).toBe(false);
+
+  // 6. Test functionality
+  await page.click("#action-button");
+  await page.waitForTimeout(500);
+
+  // 7. Capture after-action screenshot
+  const afterPath = await captureScreenshot(page, "after-button-click");
+  console.log(`After-action screenshot: ${afterPath}`);
+
+  // 8. Verify result
+  const resultText = await page.textContent("#result-display");
+  expect(resultText).toBe("Success");
+});
+```
+
+## Integration with TDD Workflow
+
+### Enhanced TDD Process
+
+1. **Write failing test** with visual verification
+2. **Run test** - it fails with screenshots showing broken state
+3. **Implement feature**
+4. **Run test** - it passes with screenshots showing correct state
+5. **Review screenshots** to confirm visual correctness
+6. **Commit** with confidence
+
+## Troubleshooting
+
+### Screenshots Not Captured
+
+Check that directory exists:
+
+```bash
+mkdir -p test-results/screenshots
+```
+
+### Can't Read Screenshots
+
+Use absolute path:
+
+```bash
+ls /Users/mark/git/pi-camera-control/test-results/screenshots/
+```
+
+### Tests Pass But UI Wrong
+
+This means assertions are too weak. Add more specific value checks:
+
+```javascript
+// Too weak
+expect(element.count()).toBe(1);
+
+// Better
+expect(element.text()).toBe("Expected Value");
+```
+
+## Summary
+
+**The visual testing pattern ensures:**
+
+1. 📸 **Screenshots captured** - Claude can "see" the UI
+2. ✅ **Values verified** - Not just existence, actual content
+3. 🖱️ **Functionality tested** - Buttons actually work
+4. 🔍 **Visual review** - Claude reads screenshots before claiming success
+
+**Result:** Catch UI bugs before the user sees them, not after.

--- a/public/js/websocket.js
+++ b/public/js/websocket.js
@@ -190,12 +190,8 @@ class WebSocketManager {
         break;
 
       case "status_update":
-        // For status_update, the camera/power data is in the message itself, not in 'data'
-        this.emit("status_update", {
-          camera: message.camera,
-          power: message.power,
-          timestamp: message.timestamp,
-        });
+        // Emit the entire message with all fields (camera, power, network, storage, discovery, intervalometer)
+        this.emit("status_update", message);
         break;
 
       case "event":

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -150,6 +150,33 @@ export function createApiRouter(
     }
   });
 
+  // Camera SD card storage information
+  router.get("/camera/storage", async (req, res) => {
+    try {
+      const currentController = getCameraController();
+      if (!currentController) {
+        return res.status(503).json(
+          createApiError("No camera available", {
+            code: ErrorCodes.CAMERA_OFFLINE,
+            component: Components.API_ROUTER,
+            operation: "getStorageInfo",
+          }),
+        );
+      }
+      const storage = await currentController.getStorageInfo();
+      res.json(storage);
+    } catch (error) {
+      logger.error("Failed to get storage info:", error);
+      res.status(500).json(
+        createApiError(error.message, {
+          code: ErrorCodes.SYSTEM_ERROR,
+          component: Components.API_ROUTER,
+          operation: "getStorageInfo",
+        }),
+      );
+    }
+  });
+
   // Get camera datetime with timezone and DST information
   router.get("/camera/datetime", async (req, res) => {
     try {

--- a/test/e2e/helpers/visual-helpers.js
+++ b/test/e2e/helpers/visual-helpers.js
@@ -1,0 +1,220 @@
+/**
+ * Visual Testing Helpers for Playwright
+ *
+ * These helpers enable Claude to "see" what's on screen through:
+ * 1. Screenshots that Claude can read and analyze
+ * 2. Value assertions that verify actual displayed content
+ * 3. Functional tests that verify button clicks work
+ */
+
+/**
+ * Capture a screenshot with a descriptive name
+ * @param {Page} page - Playwright page object
+ * @param {string} name - Descriptive name for the screenshot
+ * @returns {Promise<string>} Path to the screenshot
+ */
+export async function captureScreenshot(page, name) {
+  const sanitizedName = name.replace(/[^a-z0-9-]/gi, "-").toLowerCase();
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const path = `test-results/screenshots/${sanitizedName}-${timestamp}.png`;
+
+  await page.screenshot({
+    path,
+    fullPage: true,
+  });
+
+  return path;
+}
+
+/**
+ * Capture screenshot and get element values for verification
+ * @param {Page} page - Playwright page object
+ * @param {string} testName - Name of the test
+ * @param {Object} selectors - Object mapping names to CSS selectors
+ * @returns {Promise<Object>} Screenshot path and element values
+ */
+export async function captureAndExtractValues(page, testName, selectors) {
+  const screenshotPath = await captureScreenshot(page, testName);
+
+  const values = {};
+  for (const [name, selector] of Object.entries(selectors)) {
+    const element = page.locator(selector);
+    const count = await element.count();
+
+    if (count > 0) {
+      const isVisible = await element.isVisible().catch(() => false);
+      values[name] = {
+        exists: true,
+        visible: isVisible,
+        text: isVisible ? await element.textContent().catch(() => null) : null,
+        value: isVisible ? await element.inputValue().catch(() => null) : null,
+        disabled: await element.isDisabled().catch(() => null),
+      };
+    } else {
+      values[name] = {
+        exists: false,
+        visible: false,
+        text: null,
+        value: null,
+        disabled: null,
+      };
+    }
+  }
+
+  return { screenshotPath, values };
+}
+
+/**
+ * Test button functionality by clicking and verifying result
+ * @param {Page} page - Playwright page object
+ * @param {string} buttonSelector - CSS selector for button
+ * @param {Function} verifyFn - Async function to verify the result
+ * @returns {Promise<Object>} Result of the test
+ */
+export async function testButtonClick(page, buttonSelector, verifyFn) {
+  const button = page.locator(buttonSelector);
+
+  // Verify button exists
+  const exists = (await button.count()) > 0;
+  if (!exists) {
+    return { success: false, error: "Button not found" };
+  }
+
+  // Verify button is visible
+  const visible = await button.isVisible();
+  if (!visible) {
+    return { success: false, error: "Button not visible" };
+  }
+
+  // Verify button is enabled
+  const disabled = await button.isDisabled();
+  if (disabled) {
+    return { success: false, error: "Button is disabled" };
+  }
+
+  // Click the button
+  await button.click();
+
+  // Wait a moment for UI to update
+  await page.waitForTimeout(500);
+
+  // Verify the result
+  try {
+    await verifyFn(page);
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * Compare actual values against expected values
+ * @param {Object} actual - Actual values from page
+ * @param {Object} expected - Expected values
+ * @returns {Object} Comparison result with differences
+ */
+export function compareValues(actual, expected) {
+  const differences = [];
+
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    const actualValue = actual[key];
+
+    if (actualValue === undefined) {
+      differences.push({
+        field: key,
+        expected: expectedValue,
+        actual: "undefined",
+        type: "missing",
+      });
+    } else if (typeof expectedValue === "object") {
+      // Deep comparison for objects
+      for (const [prop, expVal] of Object.entries(expectedValue)) {
+        if (actualValue[prop] !== expVal) {
+          differences.push({
+            field: `${key}.${prop}`,
+            expected: expVal,
+            actual: actualValue[prop],
+            type: "mismatch",
+          });
+        }
+      }
+    } else if (actualValue !== expectedValue) {
+      differences.push({
+        field: key,
+        expected: expectedValue,
+        actual: actualValue,
+        type: "mismatch",
+      });
+    }
+  }
+
+  return {
+    match: differences.length === 0,
+    differences,
+  };
+}
+
+/**
+ * Wait for WebSocket connection and verify state
+ * @param {Page} page - Playwright page object
+ * @param {number} timeout - Max wait time in ms
+ * @returns {Promise<boolean>} True if connected
+ */
+export async function waitForWebSocketAndVerify(page, timeout = 10000) {
+  const connected = await page
+    .waitForFunction(
+      () => {
+        return (
+          window.wsManager &&
+          typeof window.wsManager.isConnected === "function" &&
+          window.wsManager.isConnected()
+        );
+      },
+      { timeout },
+    )
+    .then(() => true)
+    .catch(() => false);
+
+  return connected;
+}
+
+/**
+ * Get comprehensive UI state snapshot
+ * @param {Page} page - Playwright page object
+ * @returns {Promise<Object>} Complete UI state
+ */
+export async function getUIStateSnapshot(page) {
+  return await page.evaluate(() => {
+    const getElementInfo = (selector) => {
+      const el = document.querySelector(selector);
+      if (!el) return { exists: false };
+
+      return {
+        exists: true,
+        visible: el.offsetParent !== null,
+        text: el.textContent?.trim(),
+        value: el.value,
+        disabled: el.disabled,
+        classList: Array.from(el.classList),
+      };
+    };
+
+    return {
+      camera: {
+        status: getElementInfo("#camera-status-text"),
+        ip: getElementInfo("#camera-ip"),
+        battery: getElementInfo("#camera-battery"),
+        mode: getElementInfo("#camera-mode"),
+      },
+      websocket: {
+        connected: window.wsManager?.isConnected?.() || false,
+      },
+      buttons: {
+        takePhoto: getElementInfo("#take-photo-btn"),
+        startIntervalometer: getElementInfo("#start-intervalometer-btn"),
+        stopIntervalometer: getElementInfo("#stop-intervalometer-btn"),
+      },
+      timestamp: new Date().toISOString(),
+    };
+  });
+}

--- a/test/e2e/storage-indicator-visual.spec.js
+++ b/test/e2e/storage-indicator-visual.spec.js
@@ -1,0 +1,171 @@
+/**
+ * Storage Indicator Visual E2E Tests
+ *
+ * These tests verify that the storage indicator in the header displays
+ * actual SD card storage information from the camera, not hardcoded values.
+ *
+ * Requirements:
+ * - Storage indicator should show available space when camera connected
+ * - Should show actual values, not "-" or "8GB" placeholder
+ * - Should update when storage data changes
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  captureScreenshot,
+  captureAndExtractValues,
+  waitForWebSocketAndVerify,
+} from "./helpers/visual-helpers.js";
+
+test.describe("Storage Indicator Display", () => {
+  test("should display actual storage data when camera is connected", async ({
+    page,
+  }) => {
+    // Navigate to the app
+    await page.goto("http://localhost:3000");
+
+    // Wait for WebSocket connection
+    await waitForWebSocketAndVerify(page);
+
+    // Wait for status updates (camera should be connected)
+    await page.waitForTimeout(2000);
+
+    // Capture screenshot and extract storage indicator value
+    const { screenshotPath, values } = await captureAndExtractValues(
+      page,
+      "storage-indicator-connected",
+      {
+        storageText: "#storage-level-header",
+        cameraStatus: "#camera-status",
+      },
+    );
+
+    console.log(`Screenshot: ${screenshotPath}`);
+    console.log("Storage indicator text:", values.storageText.text);
+    console.log("Camera status:", values.cameraStatus.text);
+
+    // Verify storage indicator exists and is visible
+    expect(values.storageText.exists).toBe(true);
+    expect(values.storageText.visible).toBe(true);
+
+    // CRITICAL: Storage should NOT be the placeholder values
+    expect(values.storageText.text).not.toBe("-");
+    expect(values.storageText.text).not.toBe("8GB");
+
+    // Storage should show actual data (valid format)
+    const validPatterns = [
+      /^\d+G$/i, // e.g., "476G"
+      /^No SD$/i, // No SD card
+    ];
+
+    const matchesPattern = validPatterns.some((pattern) =>
+      pattern.test(values.storageText.text),
+    );
+
+    expect(matchesPattern).toBe(true);
+
+    // Log what we actually got for debugging
+    if (!matchesPattern) {
+      console.error(
+        "Storage text does not match expected patterns:",
+        values.storageText.text,
+      );
+    }
+
+    // Capture final state
+    await captureScreenshot(page, "storage-indicator-final");
+  });
+
+  test.skip('should show "No SD" when no SD card is mounted', async ({
+    page,
+  }) => {
+    // This test requires mocking the camera to return no SD card
+    // Skipped until we have camera mocking infrastructure
+    await page.goto("http://localhost:3000");
+    await waitForWebSocketAndVerify(page);
+    await page.waitForTimeout(2000);
+
+    const { screenshotPath, values } = await captureAndExtractValues(
+      page,
+      "storage-no-sd-card",
+      {
+        storageText: "#storage-level-header",
+      },
+    );
+
+    console.log(`Screenshot: ${screenshotPath}`);
+    console.log("Storage text:", values.storageText.text);
+
+    // Storage should be either a valid G value or "No SD"
+    const isValid =
+      /^\d+G$/i.test(values.storageText.text) ||
+      values.storageText.text === "No SD";
+
+    expect(isValid).toBe(true);
+  });
+
+  test.skip("storage indicator should not show placeholder after connection", async ({
+    page,
+  }) => {
+    // This test is redundant with test 1 which already verifies storage shows actual data
+    // Skipped to reduce test execution time
+    await page.goto("http://localhost:3000");
+
+    // Capture initial state
+    await captureScreenshot(page, "storage-before-connection");
+
+    // Wait for WebSocket connection and status updates
+    await waitForWebSocketAndVerify(page);
+    await page.waitForTimeout(3000); // Give time for status updates
+
+    // Capture after connection
+    const { screenshotPath, values } = await captureAndExtractValues(
+      page,
+      "storage-after-connection",
+      {
+        storageText: "#storage-level-header",
+        cameraIp: "#camera-ip",
+      },
+    );
+
+    console.log(`Screenshot: ${screenshotPath}`);
+    console.log("Storage text after connection:", values.storageText.text);
+    console.log("Camera IP:", values.cameraIp.text);
+
+    // After connection, storage should not be "-"
+    expect(values.storageText.text).not.toBe("-");
+
+    // Should show actual data
+    const showsActualData =
+      /^\d+G$/i.test(values.storageText.text) ||
+      values.storageText.text === "No SD";
+
+    expect(showsActualData).toBe(true);
+  });
+
+  test("storage value format should be consistent", async ({ page }) => {
+    await page.goto("http://localhost:3000");
+    await waitForWebSocketAndVerify(page);
+    await page.waitForTimeout(2000);
+
+    const storageElement = await page.locator("#storage-level-header");
+    const storageText = await storageElement.textContent();
+
+    console.log("Storage format test - value:", storageText);
+
+    // Verify format is one of the expected formats
+    const expectedFormats = [
+      /^\d+G$/i, // "476G"
+      /^No SD$/i, // "No SD"
+    ];
+
+    const matchesFormat = expectedFormats.some((format) =>
+      format.test(storageText),
+    );
+
+    expect(matchesFormat).toBe(true);
+
+    // Capture for visual verification
+    await captureScreenshot(page, "storage-format-verification");
+  });
+});

--- a/test/schemas/websocket-message-schemas.js
+++ b/test/schemas/websocket-message-schemas.js
@@ -70,6 +70,13 @@ const MessageSchemas = {
       network: {
         interfaces: "object",
       },
+      storage: {
+        mounted: "boolean?",
+        totalMB: "number?",
+        freeMB: "number?",
+        usedMB: "number?",
+        percentUsed: "number?",
+      },
       intervalometer: "object?",
       timesync: "object?",
       clientId: "string",
@@ -99,6 +106,13 @@ const MessageSchemas = {
       },
       network: {
         interfaces: "object",
+      },
+      storage: {
+        mounted: "boolean?",
+        totalMB: "number?",
+        freeMB: "number?",
+        usedMB: "number?",
+        percentUsed: "number?",
       },
       intervalometer: {
         running: "boolean?",

--- a/test/schemas/websocket-messages.test.js
+++ b/test/schemas/websocket-messages.test.js
@@ -112,6 +112,47 @@ describe("WebSocket Message Schema Validation", () => {
             wlan0: { connected: true },
           },
         },
+        storage: {
+          mounted: true,
+          totalMB: 32000,
+          freeMB: 8000,
+          usedMB: 24000,
+          percentUsed: 75,
+        },
+      };
+
+      const errors = validateSchema(
+        statusUpdate,
+        MessageSchemas.serverMessages.status_update,
+      );
+      expect(errors).toEqual([]);
+    });
+
+    test("status_update message with no SD card follows schema", () => {
+      const statusUpdate = {
+        type: "status_update",
+        timestamp: new Date().toISOString(),
+        camera: {
+          connected: true,
+          ip: "192.168.4.2",
+        },
+        discovery: {
+          isDiscovering: true,
+          cameras: 1,
+        },
+        power: {
+          battery: { capacity: 85 },
+          thermal: { temperature: 45.2 },
+          uptime: 3600,
+        },
+        network: {
+          interfaces: {
+            wlan0: { connected: true },
+          },
+        },
+        storage: {
+          mounted: false,
+        },
       };
 
       const errors = validateSchema(

--- a/test/unit/camera-storage.test.js
+++ b/test/unit/camera-storage.test.js
@@ -1,0 +1,366 @@
+/**
+ * Camera Storage API Tests
+ *
+ * Tests for SD card storage information via Canon CCAPI
+ */
+
+import { jest } from "@jest/globals";
+import axios from "axios";
+import { CameraController } from "../../src/camera/controller.js";
+
+// Mock axios
+const mockClient = {
+  get: jest.fn(),
+  put: jest.fn(),
+  post: jest.fn(),
+};
+
+jest.mock("axios", () => ({
+  default: {
+    create: jest.fn(() => mockClient),
+  },
+}));
+
+// Mock logger
+jest.mock("../../src/utils/logger.js", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe("Camera Storage CCAPI", () => {
+  let controller;
+
+  beforeEach(() => {
+    mockClient.get.mockClear();
+    mockClient.put.mockClear();
+    mockClient.post.mockClear();
+
+    controller = new CameraController("192.168.4.3", 443);
+    controller.connected = true; // Mock as connected
+    controller.baseUrl = "https://192.168.4.3:443";
+    controller.client = mockClient;
+  });
+
+  describe("getStorageInfo", () => {
+    test("should return storage info when camera connected with SD card mounted", async () => {
+      // Mock successful response with storage data
+      // Based on Canon CCAPI specification for devicestatus/storage
+      mockClient.get.mockResolvedValue({
+        status: 200,
+        data: {
+          storagelist: [
+            {
+              name: "SD1",
+              url: "http://192.168.4.3:8080/ccapi/ver110/contents/sd",
+              maxsize: 64424509440, // 60GB in bytes
+              spacesize: 32212254720, // 30GB free in bytes
+              contentsnumber: 1234,
+              accesscapability: "readwrite",
+            },
+          ],
+        },
+      });
+
+      const result = await controller.getStorageInfo();
+
+      // Should call the correct CCAPI endpoint
+      expect(mockClient.get).toHaveBeenCalledWith(
+        "https://192.168.4.3:443/ccapi/ver110/devicestatus/storage",
+      );
+
+      // Verify all fields are present and calculated correctly
+      expect(result).toEqual({
+        mounted: true,
+        name: "SD1",
+        totalBytes: 64424509440,
+        freeBytes: 32212254720,
+        usedBytes: 32212254720, // totalBytes - freeBytes
+        totalMB: 61440, // Math.round(64424509440 / 1024 / 1024)
+        freeMB: 30720, // Math.round(32212254720 / 1024 / 1024)
+        usedMB: 30720, // Math.round(32212254720 / 1024 / 1024)
+        percentUsed: 50, // Math.round((32212254720 / 64424509440) * 100)
+        contentCount: 1234,
+        accessMode: "readwrite",
+      });
+    });
+
+    test("should calculate MB correctly from bytes", async () => {
+      mockClient.get.mockResolvedValue({
+        status: 200,
+        data: {
+          storagelist: [
+            {
+              name: "SD1",
+              url: "http://192.168.4.3:8080/ccapi/ver110/contents/sd",
+              maxsize: 128849018880, // 120GB
+              spacesize: 107374182400, // 100GB free
+              contentsnumber: 500,
+              accesscapability: "readwrite",
+            },
+          ],
+        },
+      });
+
+      const result = await controller.getStorageInfo();
+
+      // Verify MB calculations (bytes / 1024 / 1024)
+      expect(result.totalMB).toBe(122880); // Math.round(128849018880 / 1024 / 1024)
+      expect(result.freeMB).toBe(102400); // Math.round(107374182400 / 1024 / 1024)
+      expect(result.usedMB).toBe(20480); // Math.round(21474836480 / 1024 / 1024)
+    });
+
+    test("should calculate percentage used correctly", async () => {
+      mockClient.get.mockResolvedValue({
+        status: 200,
+        data: {
+          storagelist: [
+            {
+              name: "SD1",
+              url: "http://192.168.4.3:8080/ccapi/ver110/contents/sd",
+              maxsize: 100000000, // 100MB total
+              spacesize: 25000000, // 25MB free
+              contentsnumber: 100,
+              accesscapability: "readwrite",
+            },
+          ],
+        },
+      });
+
+      const result = await controller.getStorageInfo();
+
+      // Used = 100MB - 25MB = 75MB
+      // Percentage = (75 / 100) * 100 = 75%
+      expect(result.percentUsed).toBe(75);
+    });
+
+    test("should return mounted:false when no SD card present", async () => {
+      // Mock response with empty storagelist (no SD card inserted)
+      mockClient.get.mockResolvedValue({
+        status: 200,
+        data: {
+          storagelist: [],
+        },
+      });
+
+      const result = await controller.getStorageInfo();
+
+      // Should call the endpoint
+      expect(mockClient.get).toHaveBeenCalledWith(
+        "https://192.168.4.3:443/ccapi/ver110/devicestatus/storage",
+      );
+
+      // Verify mounted: false and all numeric fields are 0
+      expect(result).toEqual({
+        mounted: false,
+        name: null,
+        totalBytes: 0,
+        freeBytes: 0,
+        usedBytes: 0,
+        totalMB: 0,
+        freeMB: 0,
+        usedMB: 0,
+        percentUsed: 0,
+        contentCount: 0,
+        accessMode: null,
+      });
+    });
+
+    test("should throw error when camera not connected", async () => {
+      controller.connected = false;
+
+      await expect(controller.getStorageInfo()).rejects.toThrow(
+        "Camera not connected",
+      );
+
+      // Should not make API call if not connected
+      expect(mockClient.get).not.toHaveBeenCalled();
+    });
+
+    test("should handle invalid CCAPI response without storagelist field", async () => {
+      // Mock invalid response (missing storagelist field)
+      mockClient.get.mockResolvedValue({
+        status: 200,
+        data: {
+          // Missing storagelist field
+        },
+      });
+
+      await expect(controller.getStorageInfo()).rejects.toThrow(
+        "Invalid storage response from camera",
+      );
+    });
+
+    test("should handle invalid CCAPI response with null data", async () => {
+      // Mock invalid response (null data)
+      mockClient.get.mockResolvedValue({
+        status: 200,
+        data: null,
+      });
+
+      await expect(controller.getStorageInfo()).rejects.toThrow(
+        "Invalid storage response from camera",
+      );
+    });
+
+    test("should handle CCAPI network error gracefully", async () => {
+      // Mock network error
+      const networkError = new Error("Network timeout");
+      networkError.response = {
+        status: 503,
+        data: { message: "Service Unavailable" },
+      };
+      mockClient.get.mockRejectedValue(networkError);
+
+      await expect(controller.getStorageInfo()).rejects.toThrow();
+    });
+
+    test("should handle CCAPI 404 error (endpoint not found)", async () => {
+      // Mock 404 error
+      const notFoundError = new Error("Not Found");
+      notFoundError.response = {
+        status: 404,
+        data: { message: "Endpoint not found" },
+      };
+      mockClient.get.mockRejectedValue(notFoundError);
+
+      await expect(controller.getStorageInfo()).rejects.toThrow();
+    });
+
+    test("should handle CCAPI 500 error (internal camera error)", async () => {
+      // Mock camera internal error
+      const serverError = new Error("Internal Server Error");
+      serverError.response = {
+        status: 500,
+        data: { message: "Camera internal error" },
+      };
+      mockClient.get.mockRejectedValue(serverError);
+
+      await expect(controller.getStorageInfo()).rejects.toThrow();
+    });
+
+    test("should handle single storage slot correctly (EOS R50 has one card slot)", async () => {
+      // EOS R50 has single SD card slot
+      mockClient.get.mockResolvedValue({
+        status: 200,
+        data: {
+          storagelist: [
+            {
+              name: "SD",
+              url: "http://192.168.4.3:8080/ccapi/ver110/contents/sd",
+              maxsize: 32000000000, // 32GB
+              spacesize: 16000000000, // 16GB free
+              contentsnumber: 500,
+              accesscapability: "readwrite",
+            },
+          ],
+        },
+      });
+
+      const result = await controller.getStorageInfo();
+
+      // Should use first (and only) storage from list
+      expect(result.mounted).toBe(true);
+      expect(result.name).toBe("SD");
+    });
+
+    test("should handle readonly access mode", async () => {
+      mockClient.get.mockResolvedValue({
+        status: 200,
+        data: {
+          storagelist: [
+            {
+              name: "SD1",
+              url: "http://192.168.4.3:8080/ccapi/ver110/contents/sd",
+              maxsize: 64424509440,
+              spacesize: 32212254720,
+              contentsnumber: 1234,
+              accesscapability: "readonly", // Card is write-protected
+            },
+          ],
+        },
+      });
+
+      const result = await controller.getStorageInfo();
+
+      expect(result.accessMode).toBe("readonly");
+    });
+
+    test("should handle very small storage (edge case)", async () => {
+      mockClient.get.mockResolvedValue({
+        status: 200,
+        data: {
+          storagelist: [
+            {
+              name: "SD1",
+              url: "http://192.168.4.3:8080/ccapi/ver110/contents/sd",
+              maxsize: 1048576, // 1MB total
+              spacesize: 524288, // 0.5MB free
+              contentsnumber: 10,
+              accesscapability: "readwrite",
+            },
+          ],
+        },
+      });
+
+      const result = await controller.getStorageInfo();
+
+      // Should calculate correctly even with small values
+      expect(result.totalMB).toBe(1); // Math.round(1048576 / 1024 / 1024)
+      expect(result.freeMB).toBe(1); // Math.round(524288 / 1024 / 1024) = 0.5, rounds to 1
+      expect(result.percentUsed).toBe(50);
+    });
+
+    test("should handle full storage (100% used)", async () => {
+      mockClient.get.mockResolvedValue({
+        status: 200,
+        data: {
+          storagelist: [
+            {
+              name: "SD1",
+              url: "http://192.168.4.3:8080/ccapi/ver110/contents/sd",
+              maxsize: 64424509440,
+              spacesize: 0, // No free space
+              contentsnumber: 5000,
+              accesscapability: "readwrite",
+            },
+          ],
+        },
+      });
+
+      const result = await controller.getStorageInfo();
+
+      expect(result.freeBytes).toBe(0);
+      expect(result.freeMB).toBe(0);
+      expect(result.percentUsed).toBe(100);
+    });
+
+    test("should handle empty storage (0% used)", async () => {
+      mockClient.get.mockResolvedValue({
+        status: 200,
+        data: {
+          storagelist: [
+            {
+              name: "SD1",
+              url: "http://192.168.4.3:8080/ccapi/ver110/contents/sd",
+              maxsize: 64424509440,
+              spacesize: 64424509440, // All space free
+              contentsnumber: 0,
+              accesscapability: "readwrite",
+            },
+          ],
+        },
+      });
+
+      const result = await controller.getStorageInfo();
+
+      expect(result.usedBytes).toBe(0);
+      expect(result.usedMB).toBe(0);
+      expect(result.percentUsed).toBe(0);
+      expect(result.contentCount).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add SD card storage monitoring to header indicator

## Test plan
- [ ] Verify SD card storage displays in header
- [ ] Test storage updates in real-time
- [ ] Confirm indicator styling matches design

🤖 Generated with [Claude Code](https://claude.com/claude-code)